### PR TITLE
Fix abbreviation and pronoun rules

### DIFF
--- a/styles/Datadog/abbreviations.yml
+++ b/styles/Datadog/abbreviations.yml
@@ -7,5 +7,6 @@ nonword: true
 action:
   name: replace
 swap:
-  '\b(?:eg|e\.g\.)[\s,]': for example
-  '\b(?:ie|i\.e\.)[\s,]': that is
+  '\b(?:eg|e\.g\.|eg\.)[\s,]': for example
+  '\b(?:ie|i\.e\.|ie\.)[\s,]': that is
+  '\b(?:etc|etc\.)[\s,]': and so on

--- a/styles/Datadog/abbreviations.yml
+++ b/styles/Datadog/abbreviations.yml
@@ -9,4 +9,4 @@ action:
 swap:
   '\b(?:eg|e\.g\.|eg\.)[\s,]': for example
   '\b(?:ie|i\.e\.|ie\.)[\s,]': that is
-  '\b(?:etc|etc\.)[\s,]': and so on
+  '\b(?:etc)[\s\n,.]': and so on

--- a/styles/Datadog/pronouns.yml
+++ b/styles/Datadog/pronouns.yml
@@ -4,14 +4,14 @@ link: "https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#pron
 level: warning
 nonword: true
 tokens:
-  - (?:^|\s)I\s
-  - (?:^|\s)I,\s
+  - (?<=^|\s)I(?=\s)
+  - (?<=^|\s)I,(?=\s)
   - \bI'm\b
-  - \s[Mm]e\b
-  - \s[Mm]y\b
-  - \s[Mm]ine\b
-  - \s[Ww]e\b
+  - (?<=\s)[Mm]e\b
+  - (?<=\s)[Mm]y\b
+  - (?<=\s)[Mm]ine\b
+  - (?<=\s)[Ww]e\b
   - we'(?:ve|re)
-  - \s[Uu]s\b
-  - \s[Oo]ur\b
+  - (?<=\s)[Uu]s\b
+  - (?<=\s)[Oo]ur\b
   - \blet's\b


### PR DESCRIPTION
- Some variations on Latin abbreviations weren't being caught
- The output for pronouns contained a bunch of extra spacing, so I'm adding some positive lookaheads/lookbehinds to get rid of those.
  
  ![Screenshot 2023-06-06 at 10 59 37 AM](https://github.com/DataDog/datadog-vale/assets/21250475/70bb15a8-2810-4aa0-a6ab-0d8a5802a427)


---

### Release checklist
- [ ] Create zip files for EACH style folder.
- [ ] Attach the zip files when creating a [release](https://github.com/DataDog/datadog-vale/releases).

