### PR TITLE
Update abbreviations.yml - swap out 'and so on' with 'and more'

### DIFF
--- a/styles/Datadog/abbreviations.yml
+++ b/styles/Datadog/abbreviations.yml
@@ -9,4 +9,4 @@ action:
 swap:
   '\b(?:eg|e\.g\.|eg\.)[\s,]': for example
   '\b(?:ie|i\.e\.|ie\.)[\s,]': that is
-  '\b(?:etc)[\s\n,.]': and so on
+  '\b(?:etc)[\s\n,.]': and more


### PR DESCRIPTION
I would argue that "and so on" is exceedingly idiomatic. like breathtakingly idiomatic. what is "so"? what is "on"? what is "so on"?

let's change it to "and more."