### PR TITLE
Fix broken yaml in words rule

### DIFF
--- a/styles/Datadog/words.yml
+++ b/styles/Datadog/words.yml
@@ -7,53 +7,53 @@ action:
   name: replace
 swap:
   # bad: good
-  'acknowledgement': acknowledgment
+  'acknowledgement': 'acknowledgment'
   'auto-complete': 'autocomplete'
-  'a number of': few|several|many
+  'a number of': 'few|several|many'
   'and/or': 'and|or|either or'
-  'back end': backend
-  'bear in mind': keep in mind
-  'below|above|down|up': the following|the next|previous
-  'Create a new': Create a|Create an
-  'culprit': cause
+  'back end': 'backend'
+  'bear in mind': 'keep in mind'
+  'below|above|down|up': 'the following|the next|previous'
+  'Create a new': 'Create a|Create an'
+  'culprit': 'cause'
   'Datadog app|Datadog application': 'Datadog|Datadog site'
   'Datadog product': 'Datadog|Datadog service'
-  'drill down|drilling down|drill into|drilling into': examine|investigate|analyze
+  'drill down|drilling down|drill into|drilling into': 'examine|investigate|analyze'
   'figure out': 'determine'
-  'fine tune|fine-tune': customize|optimize|refine
-  'for the most part': generally|usually
+  'fine tune|fine-tune': 'customize|optimize|refine'
+  'for the most part': 'generally|usually'
   'front end': 'frontend'
   'highly|very': ''
-  'hit': click|select
+  'hit': 'click|select'
   'in order to': 'to'
-  'keep in mind': consider
-  'left up to': determined by
-  'let's assume': assuming|for example, if
+  'keep in mind': 'consider'
+  'left up to': 'determined by'
+  "let's assume": 'assuming|for example, if'
   'multi-alert': 'multi alert'
   'Note that': '**Note**:'
   'obviously|obvious': ''
   'on the fly': 'real-time|real time'
-  'once': after
-  'play a hand': influence
+  'once': 'after'
+  'play a hand': 'influence'
   'please|just': ''
   'easily|easy': ''
   'quickly|quick': ''
-  'screen board': screenboard
+  'screen board': 'screenboard'
   'simply|simple': ''
-  'single pane of glass': single view|single place|single page
-  'slice and dice': filter and group
-  'stand for': represents|means
-  'reenable': re-enable
-  'run time': runtime
-  'refer to|visit': see|read|follow
-  'time board': timeboard
-  'time series': timeseries
-  'toplist': top list
+  'single pane of glass': 'single view|single place|single page'
+  'slice and dice': 'filter and group'
+  'stand for': 'represents|means'
+  'reenable': 're-enable'
+  'run time': 'runtime'
+  'refer to|visit': 'see|read|follow'
+  'time board': 'timeboard'
+  'time series': 'timeseries'
+  'toplist': 'top list'
   'tradeoff': 'trade-off'
-  'turnkey': ready to use
+  'turnkey': 'ready to use'
   'under the hood': ''
-  'utilize': use
-  'via': with|through
-  'visit': see|read
+  'utilize': 'use'
+  'via': 'with|through'
+  'visit': 'see|read'
   'webserver': 'web server'
   'web site': 'website'


### PR DESCRIPTION
Fixes an error that was stopping the words rule from firing. See [logs](https://github.com/DataDog/documentation/actions/runs/5525227722/jobs/10078573699?pr=18846#step:6:20)

Issue was on line 31 (needs double quotes to escape the apostrophe), but I added quotes to the rest of the strings for consistency

---

### Release checklist
- [ ] Create zip files for EACH style folder.
- [ ] Attach the zip files when creating a [release](https://github.com/DataDog/datadog-vale/releases).

