### PR TITLE
Turn Off Ignore Case in `Words.yml`

### DIFF
--- a/styles/Datadog/words.yml
+++ b/styles/Datadog/words.yml
@@ -1,7 +1,7 @@
 extends: substitution
 message: "Use '%s' instead of '%s'."
 link: "https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#words-and-phrases"
-ignorecase: true
+ignorecase: false
 level: warning
 action:
   name: replace
@@ -15,7 +15,7 @@ swap:
   'bear in mind': 'keep in mind'
   'Create a new': 'Create a|Create an'
   'culprit': 'cause'
-  'Datadog app|Datadog application': 'Datadog|Datadog site'
+  '(?:Datadog app|Datadog application)': 'Datadog|Datadog site'
   'Datadog product': 'Datadog|Datadog service'
   'drill down|drilling down|drill into|drilling into': 'examine|investigate|analyze'
   'figure out': 'determine'


### PR DESCRIPTION
<!-- *Note: This style guide follows the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md).* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

`ignorecase: true` means that Vale makes all matches case-insensitive. Making this `false` means that cases of "Datadog Application Key" would be ignored.

### Motivation
<!-- What inspired you to submit this pull request?-->

Chat with DeForest in #docs-style-council on Slack

### Release
<!-- Does this PR require a release?-->

- [ ] YES, this PR requires a release
- [x] NO, this PR doesn't need a release

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Release checklist
- [ ] Create zip files for EACH style folder.
- [ ] Attach the zip files when creating a [release](https://github.com/DataDog/datadog-vale/releases).

