### PR TITLE
Update link.yml To Work Without Link Scope

### DIFF
--- a/styles/Datadog/links.yml
+++ b/styles/Datadog/links.yml
@@ -7,4 +7,6 @@ nonword: true
 level: warning
 tokens:
   - \[(this|here|page)\]\(.*?\)
+  - \[this page\]\(.*?\)
   - <a\s*href\s*=\s*".*?".*?>\s*(this|here|page)\s*</a>
+  - <a\s*href\s*=\s*".*?".*?>\s*this page\s*</a>

--- a/styles/Datadog/links.yml
+++ b/styles/Datadog/links.yml
@@ -6,7 +6,6 @@ scope: raw
 nonword: true
 level: warning
 tokens:
-  - \[(this|here|page)\]\(.*?\)
-  - \[this page\]\(.*?\)
+  - \[(this|here|page|this page)\]\(.*?\)
   - <a\s*href\s*=\s*".*?".*?>\s*(this|here|page)\s*</a>
   - <a\s*href\s*=\s*".*?".*?>\s*this page\s*</a>

--- a/styles/Datadog/links.yml
+++ b/styles/Datadog/links.yml
@@ -2,9 +2,13 @@ extends: existence
 message: "Avoid vague text in links like '%s' unless you can pair it with more descriptive text."
 link: 'https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#links'
 ignorecase: true
-scope: link
+scope: raw
+nonword: true
 level: warning
 tokens:
-  - here
-  - this
-  - ^page$
+  - \[here\]\([^)]+\)
+  - \[this\]\([^)]+\)
+  - \[page\]\([^)]+\)
+  - <a\s*href\s*=\s*".*?"\s*>here</a>
+  - <a\s*href\s*=\s*".*?"\s*>this</a>
+  - <a\s*href\s*=\s*".*?"\s*>page</a>

--- a/styles/Datadog/links.yml
+++ b/styles/Datadog/links.yml
@@ -7,5 +7,18 @@ nonword: true
 level: warning
 
 swap:
-  '\[(here|this|page|this page)\]\(.*?\)': '$1'
-  '<a\s*href\s*=\s*".*?".*?>\s*(here|this|page|this page)\s*</a>': '$1'
+# For the word 'here' in Markdown and HTML links
+  '\[here\]\(.*?\)': 'here'
+  '<a\s*href\s*=\s*".*?".*?>\s*here\s*</a>': 'here'
+
+# For the word 'this' in Markdown and HTML links
+  '\[this\]\(.*?\)': 'this'
+  '<a\s*href\s*=\s*".*?".*?>\s*this\s*</a>': 'this'
+
+# For the word 'page' in Markdown and HTML links
+  '\[page\]\(.*?\)': 'page'
+  '<a\s*href\s*=\s*".*?".*?>\s*page\s*</a>': 'page'
+
+# For the phrase 'this page' in Markdown and HTML links
+  '\[this page\]\(.*?\)': 'this page'
+  '<a\s*href\s*=\s*".*?".*?>\s*this page\s*</a>': 'this page'

--- a/styles/Datadog/links.yml
+++ b/styles/Datadog/links.yml
@@ -1,11 +1,11 @@
-extends: existence
+extends: substitution
 message: "Avoid vague text in links like '%s' unless you can pair it with more descriptive text."
 link: 'https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#links'
 ignorecase: true
 scope: raw
 nonword: true
 level: warning
-tokens:
-  - \[(this|here|page|this page)\]\(.*?\)
-  - <a\s*href\s*=\s*".*?".*?>\s*(this|here|page)\s*</a>
-  - <a\s*href\s*=\s*".*?".*?>\s*this page\s*</a>
+
+swap:
+  '\[(here|this|page|this page)\]\(.*?\)': '$1'
+  '<a\s*href\s*=\s*".*?".*?>\s*(here|this|page|this page)\s*</a>': '$1'

--- a/styles/Datadog/links.yml
+++ b/styles/Datadog/links.yml
@@ -6,9 +6,5 @@ scope: raw
 nonword: true
 level: warning
 tokens:
-  - \[here\]\([^)]+\)
-  - \[this\]\([^)]+\)
-  - \[page\]\([^)]+\)
-  - <a\s*href\s*=\s*".*?"\s*>here</a>
-  - <a\s*href\s*=\s*".*?"\s*>this</a>
-  - <a\s*href\s*=\s*".*?"\s*>page</a>
+  - \[(this|here|page)\]\(.*?\)
+  - <a\s*href\s*=\s*".*?".*?>\s*(this|here|page)\s*</a>


### PR DESCRIPTION
<!-- *Note: This style guide follows the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md).* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
- Instead of using the `link` scope, use `raw`.
- Raw doesn't do much, so use `nonword` + regex to match vague links.
- Extend substitution so we can have cleaner warning messages (without this, the entire regex is captured in %s).

### Motivation
<!-- What inspired you to submit this pull request?-->
Vale [v2.26.0](https://github.com/errata-ai/vale/releases/tag/v2.26.0) removed support for the link scope we use in our links.yml style. This breaks local linting unless you are on an older version.

### Release
<!-- Does this PR require a release?-->

- [ ] YES, this PR requires a release
- [ ] NO, this PR doesn't need a release

### Additional Notes
<!-- Anything else we should know when reviewing?-->

These are the test cases I checked using a test file:
```
1. This is a [here](http://example.com) link in markdown.
2. Try [this](http://example.com) link for more info.
3. Visit the [page](http://example.com) for details.
4. Here's a link to [Datadog](http://datadoghq.com).

5. An HTML link: <a href="http://example.com">here</a>.
6. Another one: <a href="http://example.com">this</a>.
7. And one more: <a href="http://example.com">page</a>.
8. Here's an HTML link to <a href="http://datadoghq.com">Datadog</a>.

9. This shouldn't trigger: here.
10. Nor should this: this.
11. Or this: page.

12. Valid link with context: [the documentation page for Redis](http://redis.com).
13. Invalid link with vague context: [this page](http://example.com).

14. Another valid one: <a href="http://example.com">this page for Python</a>.
15. And an invalid one: <a href="http://example.com">this page</a>.

16. Checking word at end: [documentation here](http://example.com).
17. HTML version: <a href="http://example.com">documentation here</a>.

18. Another check for middle: [documentation of this specific aspect](http://example.com).
19. HTML version: <a href="http://example.com">documentation of this specific aspect</a>.
```
You should only get a warning for 1, 2, 3, 5, 6, 7, 13, 15.

Output:
![image](https://github.com/DataDog/datadog-vale/assets/84536271/f9fc7396-bdad-4886-a550-d2e704257642)


---

### Release checklist
- [ ] Create zip files for EACH style folder.
- [ ] Attach the zip files when creating a [release](https://github.com/DataDog/datadog-vale/releases).

