### PR TITLE
DOCS-6310 Add Governance to Contributing Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,8 @@ In order to ease and speed up our review, here are some items you can check for 
 - Keep commits small and focused, and rebase your branch if needed.
 - Write meaningful commit messages and pull request titles that are concise but explanatory.
 
+If you are a Datadog employee, share your pull request in #documentation and a writer on the team will take a look. 
+
 [1]: https://docs.datadoghq.com/help/
 [2]: https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md
 [3]: https://github.com/DataDog/datadog-vale/blob/main/Docsmd/gender.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,22 @@
 # Contributing
 
-First of all, thanks for contributing!
+First of all, thanks for contributing! This document provides some basic guidelines for contributing to this repository. To propose improvements, feel free to submit a pull request.
 
-This document provides some basic guidelines for contributing to this repository. To propose improvements, feel free to submit a pull request.
+## Opening issues
 
-## Submitting issues
+GitHub issues are welcome, so feel free to open an issue about an existing style rule. Make sure to add enough details and examples to explain your use case clearly.
 
-GitHub issues are welcome, so feel free to submit style requests! Make sure to add enough details to explain your use case. Are you having an issue with the Datadog product? Contact [Datadog Support][1].
+For example, if you'd like the [`words.yml` rule][7] to flag on the word "Dirrty", open an [issue][8] and include a justification in the description such as, "Dirrty is the name of a 2002 Christina Aguilera song from her album _Stripped_. If an instance of "Dirrty" appears in the documentation, it is most likely a typo." 
 
-## Pull Requests
+Are you having an issue with the Datadog product? Contact [Datadog Support][1].
 
-Have you updated an existing rule or want to propose a rule for the [Documentation Site Style Guide][2]? 
+## Submitting rules
+
+Are you interested in contributing your team's product-specific terminology and vocabulary to the [Documentation Site Style Guide][2]? 
+
+1. Create a folder such as `[Product Name]-Names` and add it to the [`Styles/Datadog` folder][4].
+2. Update the [CODEOWNERS file][5] with your team's GitHub handle.
+3. Update the `StylesPath` to point to the approriate directory in your team repository's [`.vale.ini` file][6].
 
 In order to ease and speed up our review, here are some items you can check for when submitting your pull request:
 
@@ -20,3 +26,8 @@ In order to ease and speed up our review, here are some items you can check for 
 [1]: https://docs.datadoghq.com/help/
 [2]: https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md
 [3]: https://github.com/DataDog/datadog-vale/blob/main/Docsmd/gender.yml
+[4]: https://github.com/DataDog/datadog-vale/tree/main/styles/Datadog
+[5]: https://github.com/DataDog/datadog-vale/blob/main/.github/CODEOWNERS
+[6]: https://github.com/DataDog/documentation/blob/master/.vale.ini
+[7]: https://github.com/DataDog/datadog-vale/blob/main/styles/Datadog/words.yml
+[8]: https://github.com/DataDog/datadog-vale/issues


### PR DESCRIPTION
<!-- *Note: This style guide follows the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md).* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Small cleanup on the Contributing Guidelines so teams submitting rules to our repository have some guidance and an idea of what to expect.

### Motivation
<!-- What inspired you to submit this pull request?-->

Chat with DeForest on Slack.

### Release
<!-- Does this PR require a release?-->

- [ ] YES, this PR requires a release
- [x] NO, this PR doesn't need a release

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Release checklist
- [ ] Create zip files for EACH style folder.
- [ ] Attach the zip files when creating a [release](https://github.com/DataDog/datadog-vale/releases).

