### PR TITLE
Update Wording Rule for X and Y-Axis Instances (Lowercase)

### DIFF
--- a/styles/Datadog/autodiscovery.yml
+++ b/styles/Datadog/autodiscovery.yml
@@ -6,6 +6,6 @@ level: warning
 action:
   name: replace
 swap:
-  - (?:autodiscovery|auto-discovery|Auto-discovery) : Autodiscovery|automatic detection
+  - (?:autodiscovery|auto-discovery|Auto-discovery): Autodiscovery|automatic detection
   - (?:autodiscover|auto-discover|Auto-discover): Autodiscover|automatically detect
   - (?:autodiscovered|auto-discovered|Auto-discovered): Autodiscovered|automatically detected

--- a/styles/Datadog/words.yml
+++ b/styles/Datadog/words.yml
@@ -128,8 +128,8 @@ swap:
   visit: see|read
   webserver: web server
   web site: website
-  'X-?(?:A|a)xis': x-axis
-  'Y-?(?:A|a)xis': y-axis
+  'x-(?:a)xis': X-axis
+  'y-(?:a)xis': Y-axis
 
   # proper nouns
   (?:github|Github): GitHub

--- a/styles/Datadog/words.yml
+++ b/styles/Datadog/words.yml
@@ -128,8 +128,8 @@ swap:
   visit: see|read
   webserver: web server
   web site: website
-  'x-(?:a)xis': X-axis
-  'y-(?:a)xis': Y-axis
+  'X-axis': x-axis
+  'Y-axis': y-axis
 
   # proper nouns
   (?:github|Github): GitHub


### PR DESCRIPTION
<!-- *Note: This style guide follows the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md).* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

The previous logic caught instances of uppercase and lowercase usage of x- and y-axis. This PR updates the logic so that Vale lints for instances of `X-axis` and `Y-Axis` and enforces them in [lowercase](https://datadoghq.atlassian.net/wiki/spaces/WRIT/pages/2732523547/Style+guide).

### Motivation
<!-- What inspired you to submit this pull request?-->

Raised by Rosa in #docs-style-council on Slack! 🙌🏼

### Release
<!-- Does this PR require a release?-->

- [ ] YES, this PR requires a release
- [x] NO, this PR doesn't need a release

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Release checklist
- [ ] Create zip files for EACH style folder.
- [ ] Attach the zip files when creating a [release](https://github.com/DataDog/datadog-vale/releases).

