### PR TITLE
Move vocab directory after breaking change in vale v3.0.0

### DIFF
--- a/styles/Vocab/Security/README.md
+++ b/styles/Vocab/Security/README.md
@@ -1,0 +1,2 @@
+# Deprecated
+This directory is deprecated due to a [breaking change](https://github.com/errata-ai/vale/releases/tag/v3.0.0). Use `styles/config/vocabularies/Security`.

--- a/styles/config/vocabularies/Security/README.md
+++ b/styles/config/vocabularies/Security/README.md
@@ -1,2 +1,0 @@
-# Deprecated
-This directory is deprecated due to a [breaking change](https://github.com/errata-ai/vale/releases/tag/v3.0.0). Use `styles/config/vocabularies/Security`.

--- a/styles/config/vocabularies/Security/README.md
+++ b/styles/config/vocabularies/Security/README.md
@@ -1,0 +1,2 @@
+# Deprecated
+This directory is deprecated due to a [breaking change](https://github.com/errata-ai/vale/releases/tag/v3.0.0). Use `styles/config/vocabularies/Security`.

--- a/styles/config/vocabularies/Security/accept.txt
+++ b/styles/config/vocabularies/Security/accept.txt
@@ -1,0 +1,7 @@
+SELinux
+Passwd
+Cryptocurrency
+AppArmor
+Dirty Pipe
+Name Service Switch
+Remote Desktop


### PR DESCRIPTION
<!-- *Note: This style guide follows the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md).* -->

### What does this PR do?
Copies the `Security` vocab directory to the supported location.

### Motivation
A breaking change introduced in [Vale v3.0.0](https://github.com/errata-ai/vale/releases/tag/v3.0.0) moves the location of vocab directories from `$StylesPath/Vocab` to `$StylesPath/config/vocabularies`

### Release
<!-- Does this PR require a release?-->

- [ ] YES, this PR requires a release
- [x] NO, this PR doesn't need a release

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Release checklist
- [ ] Create zip files for EACH style folder.
- [ ] Attach the zip files when creating a [release](https://github.com/DataDog/datadog-vale/releases).

