### PR TITLE
Add rule for NetFlow

### DIFF
--- a/styles/Datadog/words.yml
+++ b/styles/Datadog/words.yml
@@ -136,6 +136,7 @@ swap:
   (?:kubernetes|k8s|K8s|K8S): Kubernetes
   (?:Mapreduce|mapreduce|Map reduce|Map Reduce): MapReduce
   memcached: Memcached
+  (?:netflow|Netflow): NetFlow
   (?:nginx|Nginx): NGINX
   (?:node.js|nodeJS|NodeJS|node.JS|Node.JS): Node.js
   (?:pagerduty|pager duty|Pagerduty|Pager duty): PagerDuty


### PR DESCRIPTION
<!-- *Note: This style guide follows the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md).* -->

### What does this PR do?
NetFlow is correctly defined as camel case per the app as well as should be in the documentation guidelines. This adds a rule to catch it in vale.

<img width="1016" alt="image" src="https://github.com/DataDog/datadog-vale/assets/26307719/ab323909-a423-43bf-accd-c6697191184f">


### Motivation
https://github.com/DataDog/documentation/pull/23962

### Release
<!-- Does this PR require a release?-->

- [ ] YES, this PR requires a release
- [x] NO, this PR doesn't need a release

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Release checklist
- [ ] Create zip files for EACH style folder.
- [ ] Attach the zip files when creating a [release](https://github.com/DataDog/datadog-vale/releases).

