### PR TITLE
Allow sentence case "Further reading" heading

### DIFF
--- a/styles/Datadog/headings.yml
+++ b/styles/Datadog/headings.yml
@@ -88,6 +88,7 @@ exceptions:
   - FreeBSD
   - FreeSwitch
   - Further Reading
+  - Further reading
   - GeoIP
   - Git
   - GitHub


### PR DESCRIPTION
<!-- *Note: This style guide follows the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md).* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

"Further reading" keeps flagging. This lets it be title case or sentence case.

### Motivation
<!-- What inspired you to submit this pull request?-->

False positive on Further reading sections are muddying Vale flags.

### Release
<!-- Does this PR require a release?-->

- [ ] YES, this PR requires a release
- [x] NO, this PR doesn't need a release

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Release checklist
- [ ] Create zip files for EACH style folder.
- [ ] Attach the zip files when creating a [release](https://github.com/DataDog/datadog-vale/releases).

