### PR TITLE
Unsupported Capture Groups for aws.yml

### DIFF
--- a/styles/Datadog/aws.yml
+++ b/styles/Datadog/aws.yml
@@ -28,7 +28,7 @@ swap:
   Amazon Compute Optimizer: AWS Compute Optimizer
   Amazon Config: AWS Config
   AWS Connect: Amazon Connect
-  (Amazon|AWS) Kinesis Data Firehose: Amazon Data Firehose
+  (?:Amazon|AWS) Kinesis Data Firehose: Amazon Data Firehose
   Amazon Database Migration Service: AWS Database Migration Service
   Amazon DMS: AWS DMS
   Amazon Direct Connect: AWS Direct Connect
@@ -52,12 +52,12 @@ swap:
   AWS EKS: Amazon EKS
   AWS EKS Anywhere: Amazon EKS Anywhere
   AWS Elastic Transcoder: Amazon Elastic Transcoder
-  Amazon Elemental Media( ?[Cc]onnect): AWS Elemental MediaConnect
-  Amazon Elemental Media( ?[Cc]onvert): AWS Elemental MediaConvert
-  Amazon Elemental Media( ?[Ll]ive): AWS Elemental MediaLive
-  Amazon Elemental Media( ?[Pp]ackage): AWS Elemental MediaPackage
-  Amazon Elemental Media( ?[Ss]tore): AWS Elemental MediaStore
-  Amazon Elemental Media( ?[Tt]ailor): AWS Elemental MediaTailor
+  "Amazon Elemental Media(?: ?[Cc]onnect)": AWS Elemental MediaConnect
+  "Amazon Elemental Media(?: ?[Cc]onvert)": AWS Elemental MediaConvert
+  "Amazon Elemental Media(?: ?[Ll]ive)": AWS Elemental MediaLive
+  "Amazon Elemental Media(?: ?[Pp]ackage)": AWS Elemental MediaPackage
+  "Amazon Elemental Media(?: ?[Ss]tore)": AWS Elemental MediaStore
+  "Amazon Elemental Media(?: ?[Tt]ailor)": AWS Elemental MediaTailor
   AWS EMR: Amazon EMR
   AWS EventBridge: Amazon EventBridge
   Amazon Fargate: AWS Fargate


### PR DESCRIPTION
<!-- *Note: This style guide follows the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md).* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
- Fixes Vale capture group error: Corrects the capture group not supported error by converting regex capturing groups (...) to non-capturing groups (?:...) when the captured text is not used in the replacement.

- Fixes YAML parsing error: Adds double quotes around the regex keys in the swap table. This prevents the colon inside the non-capturing group (?:...) from breaking YAML syntax.

Error: `aws.yml:55:3: capture group not supported; use '(?:' instead of '('`

Test:

<img width="679" height="178" alt="image" src="https://github.com/user-attachments/assets/a3c3b82e-8b4d-4b8c-8719-4a5b1d45be41" />

### Motivation
<!-- What inspired you to submit this pull request?-->

### Release
<!-- Does this PR require a release?-->

- [ ] YES, this PR requires a release
- [x] NO, this PR doesn't need a release

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Release checklist
- [ ] Create zip files for EACH style folder.
- [ ] Attach the zip files when creating a [release](https://github.com/DataDog/datadog-vale/releases).

