### PR TITLE
[K9] Reduce severity after annotations update

### DIFF
--- a/styles/CWS-Descriptions/agent.yml
+++ b/styles/CWS-Descriptions/agent.yml
@@ -1,6 +1,6 @@
 extends: substitution
 message: Refer to the 'Datadog %s' instead of the 'Datadog %s'
-level: error
+level: warning
 ignorecase: false
 swap:
   agent: Agent

--- a/styles/CWS-Names/namecase.yml
+++ b/styles/CWS-Names/namecase.yml
@@ -1,6 +1,6 @@
 extends: capitalization
 message: Rule names should use sentence case
-level: error
+level: warning
 match: $sentence
 exceptions:
   - OverlayFS

--- a/styles/CWS-Names/namenewvalue.yml
+++ b/styles/CWS-Names/namenewvalue.yml
@@ -1,6 +1,6 @@
 extends: substitution
 message: New Value rules should use '%s' instead of '%s'
-level: error
+level: warning
 ignorecase: true
 swap:
   unrecognized: unfamiliar

--- a/styles/CWS-Names/nameweak.yml
+++ b/styles/CWS-Names/nameweak.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: Rule names should avoid weak works like '%s'
-level: error
+level: warning
 ignorecase: true
 link: https://developers.google.com/tech-writing/one/clear-sentences
 tokens:

--- a/styles/SIEM-Names/namecase.yml
+++ b/styles/SIEM-Names/namecase.yml
@@ -1,6 +1,6 @@
 extends: capitalization
 message: Rule names should use sentence case
-level: error
+level: warning
 match: $sentence
 exceptions:
   - 1Password


### PR DESCRIPTION
<!-- *Note: This style guide follows the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md).* -->

### What does this PR do?

Reduces the level of most rules from `error` to `warning` 

### Motivation
The Vale check in our CI is no longer limited to pass/fail which enables the option for warnings.

### Release
<!-- Does this PR require a release?-->

- [ ] YES, this PR requires a release
- [x] NO, this PR doesn't need a release

---

### Release checklist
- [ ] Create zip files for EACH style folder.
- [ ] Attach the zip files when creating a [release](https://github.com/DataDog/datadog-vale/releases).

