### PR TITLE
Add abbreviations warnings

### DIFF
--- a/styles/Datadog/Trademarks.yml
+++ b/styles/Datadog/Trademarks.yml
@@ -1,3 +1,4 @@
+# This file is used to lint trademarks.
 extends: existence
 message: Missing ™ on phrase '%s'
 link: https://www.datadoghq.com

--- a/styles/Datadog/abbreviations.yml
+++ b/styles/Datadog/abbreviations.yml
@@ -1,3 +1,4 @@
+# This file is used to lint abbreviations that are common across all languages.
 extends: substitution
 message: "Use abbreviations for common industry terms: '%s' instead of '%s'."
 link: "https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#abbreviations"

--- a/styles/Datadog/abbreviations_latin.yml
+++ b/styles/Datadog/abbreviations_latin.yml
@@ -1,3 +1,4 @@
+# This file is used to lint abbreviations that are specific to Latin languages.
 extends: substitution
 message: "Use '%s' instead of abbreviations like '%s'."
 link: "https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#abbreviations"

--- a/styles/Datadog/americanspelling.yml
+++ b/styles/Datadog/americanspelling.yml
@@ -1,3 +1,4 @@
+# This file is used to lint American spelling instead of British spelling.
 extends: existence
 message: "In general, use American spelling instead of '%s'."
 link: 'https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md'

--- a/styles/Datadog/autodiscovery.yml
+++ b/styles/Datadog/autodiscovery.yml
@@ -1,3 +1,4 @@
+# This file is used to lint autodiscovery instead of automatic discovery.
 extends: substitution
 message: "Use %s (the former, to refer to Datadog's mechanism for applying integration configurations to containers; the latter, to refer to automatic discovery IN GENERAL) instead of '%s'."
 link: 'https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#words-and-phrases'

--- a/styles/Datadog/aws.yml
+++ b/styles/Datadog/aws.yml
@@ -1,3 +1,4 @@
+# This file is used to lint AWS services.
 extends: substitution
 message: "Use the proper trademark '%s' instead of '%s'."
 link: 'https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md'

--- a/styles/Datadog/dashes.yml
+++ b/styles/Datadog/dashes.yml
@@ -1,3 +1,4 @@
+# This file is used to lint dashes.
 extends: existence
 message: "Don't put a space before or after a dash."
 link: "https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#dashes"

--- a/styles/Datadog/endash.yml
+++ b/styles/Datadog/endash.yml
@@ -1,3 +1,4 @@
+# This file is used to lint en dashes.
 extends: existence
 message: "Avoid en dashes ('–'). For hyphenated words, use a hyphen ('-').\nFor parenthesis, use an em dash ('—')."
 link: "https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#dashes"

--- a/styles/Datadog/gender.yml
+++ b/styles/Datadog/gender.yml
@@ -1,3 +1,4 @@
+# This file is used to lint gender-neutral pronouns.
 extends: existence
 message: "Use a gender-neutral pronoun instead of '%s'."
 link: "https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#gender"

--- a/styles/Datadog/headings.yml
+++ b/styles/Datadog/headings.yml
@@ -1,3 +1,4 @@
+# This file is used to lint headings that do not capitalize product and feature names correctly.
 extends: capitalization
 message: "'%s' should use sentence-style capitalization."
 link: "https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#headers"

--- a/styles/Datadog/inclusive.yml
+++ b/styles/Datadog/inclusive.yml
@@ -1,3 +1,4 @@
+# This file is used to lint inclusive language.
 extends: substitution
 message: "Use '%s' instead of '%s'."
 link: "https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#inclusive-language"

--- a/styles/Datadog/links.yml
+++ b/styles/Datadog/links.yml
@@ -1,3 +1,4 @@
+# This file is used to lint vague text in links.
 extends: substitution
 message: "Avoid vague text in links like '%s' unless you can pair it with more descriptive text."
 link: 'https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#links'

--- a/styles/Datadog/merge_conflict.yml
+++ b/styles/Datadog/merge_conflict.yml
@@ -1,3 +1,4 @@
+# This file is used to lint merge conflicts.
 extends: existence
 message: "It looks like you have a merge conflict! Fix the conflict and try again."
 link: "https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#dashes"

--- a/styles/Datadog/oxfordcomma.yml
+++ b/styles/Datadog/oxfordcomma.yml
@@ -1,3 +1,4 @@
+# This file is used to lint the Oxford comma.
 extends: existence
 message: "Use the Oxford comma in '%s'."
 link: "https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#commas"

--- a/styles/Datadog/pronouns.yml
+++ b/styles/Datadog/pronouns.yml
@@ -1,3 +1,4 @@
+# This file is used to lint first-person pronouns.
 extends: existence
 message: "Avoid first-person pronouns such as '%s'."
 link: "https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#pronouns"

--- a/styles/Datadog/quotes.yml
+++ b/styles/Datadog/quotes.yml
@@ -1,3 +1,4 @@
+# This file is used to lint smart quotes.
 extends: existence
 message: Use straight quotes instead of smart quotes.
 level: error

--- a/styles/Datadog/sentencelength.yml
+++ b/styles/Datadog/sentencelength.yml
@@ -1,3 +1,4 @@
+# This file is used to lint sentence length.
 extends: occurrence
 message: "Try to keep your sentence length to 25 words or fewer."
 level: suggestion

--- a/styles/Datadog/spaces.yml
+++ b/styles/Datadog/spaces.yml
@@ -1,3 +1,4 @@
+# This file is used to lint spaces.
 extends: existence
 message: "Use only one space between words and sentences (not two)."
 link: 'https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#spaces'

--- a/styles/Datadog/tense.yml
+++ b/styles/Datadog/tense.yml
@@ -1,3 +1,4 @@
+# This file is used to lint temporal words.
 extends: existence
 message: "Avoid temporal words like '%s'."
 link: 'https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#tense'

--- a/styles/Datadog/time.yml
+++ b/styles/Datadog/time.yml
@@ -1,3 +1,4 @@
+# This file is used to lint time formatting.
 extends: existence
 message: "Format times as 'HOUR:MINUTE a.m.' or HOUR:MINUTE p.m.' instead of '%s'."
 link: "https://datadoghq.atlassian.net/wiki/spaces/WRIT/pages/2732523547/Style+guide#%s"


### PR DESCRIPTION
<!-- *Note: This style guide follows the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md).* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Previously, the `abbreviations.yml` file housed the Latin abbreviations. This update adds new abbreviations and splits the abbreviations off into two different files:
  - `latinabbreviations.yml` contains the rule for Latin abbreviations (`.e.g.`, `i.e.`) 
  - `abbreviations.yml` contains the new rule for common industry terms

Also adds a description to each Datadog style file.

### Motivation
<!-- What inspired you to submit this pull request?-->
The Technical Content team recently updated their list of abbreviations that don't need to be spelled out, which is relevant to the docs as well.

### Release
<!-- Does this PR require a release?-->

- [ ] YES, this PR requires a release
- [ ] NO, this PR doesn't need a release

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Release checklist
- [ ] Create zip files for EACH style folder.
- [ ] Attach the zip files when creating a [release](https://github.com/DataDog/datadog-vale/releases).

