### PR TITLE
Add rule for consistent punctuation in lists

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -32,3 +32,4 @@ Datadog.tense = YES
 Datadog.words = YES
 Datadog.quotes = YES
 Datadog.aws = YES
+Datadog.listpunctuation = YES

--- a/styles/Datadog/listpunctuation.yml
+++ b/styles/Datadog/listpunctuation.yml
@@ -1,28 +1,11 @@
-# Rule 1: Detect list items without ending punctuation
-# This helps identify when list items might need periods for consistency
 extends: existence
-message: "List item without ending punctuation. Consider adding a period if other items in the list have periods."
+message: "List items should have consistent punctuation."
 link: "https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#lists"
-level: suggestion
+level: warning
 scope: raw
-ignorecase: false
+ignorecase: true
 tokens:
-  # Match bulleted list items that don't end with punctuation
-  - '^(?:\s*)(?:[\•\-\*\+])\s+[^.!?]*[a-zA-Z0-9)]\s*$'
-  # Match numbered list items that don't end with punctuation
-  - '^(?:\s*)(?:\d+\.)\s+[^.!?]*[a-zA-Z0-9)]\s*$'
-
----
-# Rule 2: Detect list items with ending punctuation
-# This helps identify when list items might not need periods for consistency
-extends: existence
-message: "List item with ending punctuation. Consider removing the period if other items in the list don't have periods."
-link: "https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#lists"
-level: suggestion
-scope: raw
-ignorecase: false
-tokens:
-  # Match bulleted list items that end with punctuation
-  - '^(?:\s*)(?:[\•\-\*\+])\s+[^.!?]*[.!?]\s*$'
-  # Match numbered list items that end with punctuation
-  - '^(?:\s*)(?:\d+\.)\s+[^.!?]*[.!?]\s*$'
+  # Match bulleted list items starting with -
+  - '^\s*-\s+.*$'
+  # Match numbered list items
+  - '^\s*\d+\.\s+.*$'


### PR DESCRIPTION
<!-- *Note: This style guide follows the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md).* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This adds a rule for consistent punctuation in list items

### Motivation
<!-- What inspired you to submit this pull request?-->

### Release
<!-- Does this PR require a release?-->

- [ ] YES, this PR requires a release
- [x] NO, this PR doesn't need a release

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Release checklist
- [ ] Create zip files for EACH style folder.
- [ ] Attach the zip files when creating a [release](https://github.com/DataDog/datadog-vale/releases).

