### PR TITLE
Add list check

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -33,3 +33,4 @@ Datadog.words_case_sensitive = YES
 Datadog.words_case_insensitive = YES
 Datadog.quotes = YES
 Datadog.aws = YES
+Datadog.lists = YES

--- a/styles/Datadog/lists.yml
+++ b/styles/Datadog/lists.yml
@@ -7,8 +7,8 @@ level: warning
 action:
   name: edit
   params:
-  - regex
-  - '(\n+\s*)[a-z]\. ' # pattern
-  - '$11. ' # replace
+    - regex
+    - '(\n+\s*)[a-z]\. ' # pattern
+    - '$11. ' # replace
 tokens:
   - '(?<=\n\s*)([a-z]\.) '

--- a/styles/Datadog/lists.yml
+++ b/styles/Datadog/lists.yml
@@ -1,0 +1,14 @@
+# This file is used to lint lists.
+extends: existence
+message: "For ordered lists at all levels, use numbers (1.) instead of letters (a.)."
+scope: raw
+nonword: true
+level: warning
+action:
+  name: edit
+  params:
+  - regex
+  - '(\n+\s*)[a-z]\. ' # pattern
+  - '$11. ' # replace
+tokens:
+  - '(?<=\n\s*)([a-z]\.) '


### PR DESCRIPTION
<!-- *Note: This style guide follows the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md).* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
New rule that checks for ordered lists that start with letters rather than numbers, because those lists render funny.

### Motivation
<!-- What inspired you to submit this pull request?-->
Example of funny rendering:
<img width="761" height="565" alt="image" src="https://github.com/user-attachments/assets/4efc015e-b816-4c1a-ab69-1e78085cf557" />

Example of detection with new rule:
<img width="846" height="124" alt="image" src="https://github.com/user-attachments/assets/795a2cb5-d60f-4d8a-8d11-d4b09fc3ac5a" />


### Release
<!-- Does this PR require a release?-->

- [ ] YES, this PR requires a release
- [x] NO, this PR doesn't need a release

### Additional Notes
<!-- Anything else we should know when reviewing?-->
There are a bunch of parakeets running wild around London, and no one knows where they came from.
---

### Release checklist
- [ ] Create zip files for EACH style folder.
- [ ] Attach the zip files when creating a [release](https://github.com/DataDog/datadog-vale/releases).

