### PR TITLE
Enforce heatmap as one word

### DIFF
--- a/styles/Datadog/words_case_insensitive.yml
+++ b/styles/Datadog/words_case_insensitive.yml
@@ -68,8 +68,8 @@ swap:
   'front(?:\s|-)end': frontend
   (?:health-?check): health check
   (?:health-?checks): health checks
-  (?:heat-?map): heat map
-  (?:heat-?maps): heat maps
+  'heat(?:\s|-)map': heatmap
+  'heat(?:\s|-)maps': heatmaps
   (?:host-?map): host map
   (?:host-?maps): host maps
   holistic: complete|comprehensive|integrated


### PR DESCRIPTION
Updates `words_case_insensitive.yml` to flag "heat map" and "heat-map" and suggest "heatmap" instead.

The widget in the Datadog app is styled "heatmap," and the Technical Content team already [has it as one word in their word list](https://datadoghq.atlassian.net/wiki/spaces/WRITING/pages/3541042054/Word+List#heatmap), so we should update our style rules to match.

cc @omar-datadog 