### PR TITLE
Add app_links Vale rule to flag private internal URLs

### DIFF
--- a/styles/Datadog/app_links.yml
+++ b/styles/Datadog/app_links.yml
@@ -12,3 +12,5 @@ swap:
   'https?://(?:dd[a-zA-Z0-9\-]*|demo)\.datadoghq\.com': https://app.datadoghq.com
   # Matches the internal zero-substitution domain variant
   'https?://(?:[a-zA-Z0-9][a-zA-Z0-9\-]*\.)?datad0g\.com': https://app.datadoghq.com
+  # Matches app.datadog.com (missing 'hq')
+  'https?://app\.datadog\.com': https://app.datadoghq.com

--- a/styles/Datadog/app_links.yml
+++ b/styles/Datadog/app_links.yml
@@ -1,0 +1,14 @@
+# This file is used to lint links to internal Datadog environments that are not accessible to customers.
+extends: substitution
+message: "This looks like a private app link. Use '%s' instead of '%s'."
+link: "https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#links"
+ignorecase: true
+level: error
+scope: raw
+action:
+  name: replace
+swap:
+  # Matches known internal subdomain patterns on the product domain
+  'https?://(?:dd[a-zA-Z0-9\-]*|demo)\.datadoghq\.com': https://app.datadoghq.com
+  # Matches the internal zero-substitution domain variant
+  'https?://(?:[a-zA-Z0-9][a-zA-Z0-9\-]*\.)?datad0g\.com': https://app.datadoghq.com


### PR DESCRIPTION
## Summary
- Adds a new `app_links` Vale rule that flags links to internal Datadog environments not accessible to customers
- Catches `dd*.datadoghq.com`, `demo.datadoghq.com`, `datad0g.com`, and `app.datadog.com` URL patterns
- Suggests `https://app.datadoghq.com` as the replacement with an auto-fix action

🤖 Generated with [Claude Code](https://claude.com/claude-code)