### PR TITLE
Adding rule for recommendation phrasing

### DIFF
--- a/styles/Datadog/recommendations.yml
+++ b/styles/Datadog/recommendations.yml
@@ -1,0 +1,9 @@
+# This file is used to lint passive "it is recommended" phrasing.
+extends: substitution
+message: "Use '%s' instead of '%s'."
+ignorecase: true
+level: warning
+action:
+  name: replace
+swap:
+  "it(?:'s| is) recommended to": Datadog recommends


### PR DESCRIPTION
### What does this PR do?
adds a warning for passive "it is recommended" phrasing and suggests using "Datadog recommends" instead.

### Motivation
@buraizu [reminded me of this convention](https://github.com/DataDog/documentation/pull/35343/changes#r3126432075) in his review of my PR! thanks Bryce!

### Release
I don't think this PR requires a release! looking at the [Releases page](https://github.com/DataDog/datadog-vale/releases), they seem infrequent and not required for new rules to be disseminated to this repo's users

- [ ] YES, this PR requires a release
- [x] NO, this PR doesn't need a release

### Additional Notes
n/a

---

### Release checklist
- [ ] Create zip files for EACH style folder.
- [ ] Attach the zip files when creating a [release](https://github.com/DataDog/datadog-vale/releases).

