### PR TITLE
Add Vale rule for tracing library → SDK terminology

### DIFF
--- a/styles/Datadog/words_case_insensitive.yml
+++ b/styles/Datadog/words_case_insensitive.yml
@@ -155,6 +155,8 @@ swap:
   time-?series: timeseries
   top-?list: top list
   towards: toward
+  tracing libraries: Datadog SDKs|SDKs
+  tracing library: Datadog SDK|SDK
   'trade(?:\s|-)off': trade-off
   turn(?:\s|-)key: turnkey|ready to use
   under(?:\s|-)provision: underprovision


### PR DESCRIPTION
## Summary
- Adds substitution rules to flag "tracing library" → "Datadog SDK" / "SDK" and "tracing libraries" → "Datadog SDKs" / "SDKs"
- Supports the ongoing terminology rename from "tracing library" to "SDK" across Datadog documentation

Future safety net for https://github.com/DataDog/documentation/pull/35358

## Test plan
- [x] Verified the rule fires correctly with `vale` against a test file