### PR TITLE
Adding the 'not' version of the recommendation rule

### DIFF
--- a/styles/Datadog/recommendations.yml
+++ b/styles/Datadog/recommendations.yml
@@ -1,4 +1,4 @@
-# This file is used to lint passive "it is recommended" phrasing.
+# This file is used to lint passive "it is (not) recommended" phrasing.
 extends: substitution
 message: "Use '%s' instead of '%s'."
 ignorecase: true
@@ -6,4 +6,5 @@ level: warning
 action:
   name: replace
 swap:
-  "it(?:'s| is) recommended to": Datadog recommends
+  "it(?:'s| is) recommended": Datadog recommends
+  "it(?:'s| is) not recommended": Datadog does not recommend


### PR DESCRIPTION
### What does this PR do?
Adds the "not" version of the rule, so that it'll catch "it's not recommended" in addition to "it's recommended"
Also removes "to" from the original version, after seeing some "it's recommended that" in our docs

### Motivation
I merged my PR that creates this rule(https://github.com/DataDog/datadog-vale/pull/90) a couple hours ago, and it just randomly hit me that this opposite is needed as well! 

### Release
- [ ] YES, this PR requires a release
- [x] NO, this PR doesn't need a release

### Additional Notes
n/a
---

### Release checklist
- [ ] Create zip files for EACH style folder.
- [ ] Attach the zip files when creating a [release](https://github.com/DataDog/datadog-vale/releases).

