### PR TITLE
Add rule to flag id-for-anchoring placeholder

### DIFF
--- a/styles/Datadog/id_placeholder.yml
+++ b/styles/Datadog/id_placeholder.yml
@@ -1,0 +1,8 @@
+# This file is used to flag the `id-for-anchoring` placeholder left over from the `collapse-content` shortcode template.
+extends: existence
+message: "Replace the 'id-for-anchoring' placeholder with a unique, descriptive ID for this collapse-content section so anchor links work."
+link: "https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md"
+nonword: true
+level: error
+tokens:
+  - 'id-for-anchoring'


### PR DESCRIPTION
## Summary

Adds a Vale rule that flags the literal `id-for-anchoring` placeholder text. This placeholder comes from the `collapse-content` shortcode template and is meant to be replaced by writers with a unique, descriptive ID for the expander. When left in place, anchor links to the section don't work and multiple expanders on the same page collide on the same ID.

Recent instances of the placeholder slipping through to merged docs: [documentation#36760](https://github.com/DataDog/documentation/pull/36760) cleaned up 22 of them across 10 pages.

The rule uses the same `existence` pattern as `merge_conflict.yml` — a hard `error` level for a token that should never appear in published content.

## Test plan

- [ ] Run Vale locally against a doc file containing `id="id-for-anchoring"` and confirm the rule fires with the expected message.
- [ ] Run Vale against a doc file without the placeholder and confirm the rule does not fire.